### PR TITLE
TowersBlockTrialVideo and few columns

### DIFF
--- a/schemas/+behavior/Jobs.m
+++ b/schemas/+behavior/Jobs.m
@@ -1,0 +1,16 @@
+%{
+# the job reservation table for +behavior
+table_name : varchar(255) # className of the table
+key_hash   : char(32)     # key hash
+-----
+status    : enum("reserved","error","ignore") # if tuple is missing, the job is available
+key=null           : blob                     # structure containing the key
+error_message=""   : varchar(1023)            # error message returned if failed
+error_stack=null   : blob                     # error stack if failed
+host=""            : varchar(255)             # system hostname
+pid=0              : int unsigned             # system process id
+timestamp=CURRENT_TIMESTAMP : timestamp       # automatic timestamp
+%}
+
+classdef Jobs < dj.Jobs
+end

--- a/schemas/+behavior/TowersBlockTrialVideo.m
+++ b/schemas/+behavior/TowersBlockTrialVideo.m
@@ -1,0 +1,15 @@
+%{
+-> behavior.TowersBlockTrial
+---
+video_path:                 varchar(255)         # video directory + filename for each trial
+%}
+
+classdef TowersBlockTrialVideo < dj.Imported
+   % properties(SetAccess=protected)
+   %     master = behavior.TowersBlock
+   % end
+   methods(Access=protected)
+        function makeTuples(self, key)
+        end
+   end
+end

--- a/schemas/+lab/AcquisitionType.m
+++ b/schemas/+lab/AcquisitionType.m
@@ -1,0 +1,11 @@
+%{
+# The type of acquisition that was performed on a session given a certain location
+acquisition_type:              varchar(64)
+-----
+acquisition_description='':    varchar(255)
+%}
+
+classdef AcquisitionType < dj.Lookup
+    properties
+    end
+end

--- a/schemas/+lab/Location.m
+++ b/schemas/+lab/Location.m
@@ -4,6 +4,8 @@
 location:                   varchar(32)
 -----
 location_description='':    varchar(255)
+acquisition_type='':        varchar(128)     #to define if it's mesoscope or 2_3photon imaging
+
 %}
 
 classdef Location < dj.Lookup

--- a/schemas/+lab/Location.m
+++ b/schemas/+lab/Location.m
@@ -3,8 +3,8 @@
 # This could be a room, a rig or a bench.
 location:                   varchar(32)
 -----
+-> lab.AcquisitionType
 location_description='':    varchar(255)
-acquisition_type='':        varchar(128)     #to define if it's mesoscope or 2_3photon imaging
 
 %}
 

--- a/schemas/+lab/Path.m
+++ b/schemas/+lab/Path.m
@@ -4,7 +4,7 @@ system              : enum('windows', 'mac', 'linux')
 ---
 local_path          : varchar(255)               # local computer path
 net_location        : varchar(255)               # location on the network
-spock_path          : varchar(255)               # local spock path
+bucket_path         : varchar(255)               # local bucket path
 description=null    : varchar(255)
 %}
 

--- a/schemas/+lab/Path.m
+++ b/schemas/+lab/Path.m
@@ -4,6 +4,7 @@ system              : enum('windows', 'mac', 'linux')
 ---
 local_path          : varchar(255)               # local computer path
 net_location        : varchar(255)               # location on the network
+spock_path          : varchar(255)               # local spock path
 description=null    : varchar(255)
 %}
 

--- a/schemas/+subject/Cage.m
+++ b/schemas/+subject/Cage.m
@@ -1,5 +1,5 @@
 %{
-cage:  char(8)    # name of a cage
+cage:  char(16)    # name of a cage
 ---
 (cage_owner) -> lab.User
 %}


### PR DESCRIPTION
Added the TowersBlockTrialVideo definition for the u19_behavior database
Added acquisition_type column for u19_lab.location table to differentiate which locations are 2 or 3 photon,  mesoscope or just behavior (for “unified” pipeline purposes)
Added spock_path to the u19_lab.Path table, just to return correct path depending on which system you are (local windos, mac, linux or spock itself)
u19_subject.Cage, cage column now it is length 16 instead of 8